### PR TITLE
Fixed sockets not accepting IPv6 addresses because they had square brackets.

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,10 +70,10 @@ for (const [type, constructor, defaultPort] of [
     const url = new URL(`fake-protocol://${host || '127.0.0.1'}`);
     servers.add(
       new constructor({
-        target: argv.target,
+        target: argv.target.replace(/[\[\]]/g, ""),
         targetPort: argv.targetPort,
         port: url.port || defaultPort,
-        address: url.hostname
+        address: url.hostname.replace(/[\[\]]/g, "")
       })
     );
   }

--- a/lib/SubscriptionPool.js
+++ b/lib/SubscriptionPool.js
@@ -28,6 +28,7 @@ export default class SubscriptionPool {
   }
 
   async sendUpstream(data, client) {
+    const targetSP = argv.target.replace(/[\[\]]/g, "");
     const key = data.toString();
     if (!whitelist.has(key)) {
       return false;
@@ -39,7 +40,7 @@ export default class SubscriptionPool {
         clients,
         socketPromise: new Promise((resolve, reject) => {
           const socket = dgram.createSocket(
-            net.isIPv6(argv.target) ? 'udp6' : 'udp4'
+            net.isIPv6(targetSP) ? 'udp6' : 'udp4'
           );
           socket.once('error', reject);
           socket.once('listening', resolve.bind(this, socket));
@@ -67,7 +68,7 @@ export default class SubscriptionPool {
       }, {once: true});
     }
 
-    socket.send(data, argv.targetPort, argv.target);
+    socket.send(data, argv.targetPort, targetSP);
     return true;
   }
 }


### PR DESCRIPTION
The constructor of the URL object used in index.js when a string containing an IPv6 address with square brackets is assigned to $host variable returns the IPv6 address with the square brackets which socket.bind() and socket.send() doesn't accept.