### PR TITLE
Improve WebSocket client address resolution and robustness

### DIFF
--- a/lib/WsServer.js
+++ b/lib/WsServer.js
@@ -17,8 +17,15 @@ export default class WsServer extends Server {
 
     this.wss.on('connection', (stream, req) => {
       const client = new WsClient({
-        downstreamAddress: req.socket.remoteAddress,
-        downstreamPort: req.socket.remotePort,
+        downstreamAddress: (
+          req.headers['x-forwarded-for'] ||
+          req.socket?.remoteAddress ||
+          req.connection?.remoteAddress
+        ),
+        downstreamPort: (
+          req.socket?.remotePort ||
+          req.connection?.remotePort
+        ),
         downstreamSocket: stream,
         server: this,
         upstreamAddress: opts.target,


### PR DESCRIPTION
This is not a fix for #7 - confirmed that is a hard regression on the Deno side with their "node:http" compatibility layer.  However did make some changes that I think improves the codebase and was worth putting up for a PR.

1.  **Address Resolution**:
    Updated the `connection` handler to resolve the address from multiple sources in priority order:
    - `req.headers['x-forwarded-for']` (New feature: Support for proxies/load balancers)
    - `req.socket.remoteAddress` (Standard Node.js)
    - `req.connection.remoteAddress` (Legacy fallback)

2.  **Safety**:
    - Used optional chaining (`?.`) to prevent server crashes if `req.socket` is missing or malformed.
   
Changes passed the automated testing .
